### PR TITLE
Bug http header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ test: uninstall install
 	cd tests && nosetests -v --with-coverage --cover-package=vlab_gateway_api
 
 images: build
-	sudo docker build -f ApiDockerfile -t willnx/vlab-gateway-api .
-	sudo docker build -f WorkerDockerfile -t willnx/vlab-gateway-worker .
+	docker build -f ApiDockerfile -t willnx/vlab-gateway-api .
+	docker build -f WorkerDockerfile -t willnx/vlab-gateway-worker .
 
 up:
 	docker-compose -p vlabGateway up --abort-on-container-exit

--- a/vlab_gateway_api/app.ini
+++ b/vlab_gateway_api/app.ini
@@ -12,3 +12,4 @@ gid = nobody
 disable-logging = true
 enabled-threads = True
 listen = 500
+buffer-size=32768


### PR DESCRIPTION
Large auth tokens cause uWSGI to reject the HTTP header due to size. Fix is to just increase the max HTTP header size uWSGI allows.