### PR TITLE
GET POST DELETE on /api/1/inf/gateway now sets the Link header

### DIFF
--- a/tests/test_gateway_view.py
+++ b/tests/test_gateway_view.py
@@ -44,6 +44,16 @@ class TestGatewayView(unittest.TestCase):
 
         self.assertEqual(task_id, expected)
 
+    def test_get_task_link(self):
+        """GatewayView - GET on /api/1/inf/gateway sets the Link header"""
+        resp = self.app.get('/api/1/inf/gateway',
+                            headers={'X-Auth': self.token})
+
+        task_id = resp.headers['Link']
+        expected = '<https://localhost/api/1/inf/gateway/task/asdf-asdf-asdf>; rel=status'
+
+        self.assertEqual(task_id, expected)
+
     def test_post_task(self):
         """GatewayView - POST on /api/1/inf/gateway returns a task-id"""
         resp = self.app.post('/api/1/inf/gateway',
@@ -52,6 +62,17 @@ class TestGatewayView(unittest.TestCase):
 
         task_id = resp.json['content']['task-id']
         expected = 'asdf-asdf-asdf'
+
+        self.assertEqual(task_id, expected)
+
+    def test_post_task_link(self):
+        """GatewayView - POST on /api/1/inf/gateway sets the Link header"""
+        resp = self.app.post('/api/1/inf/gateway',
+                            headers={'X-Auth': self.token},
+                            json={'wan': "someWAN", 'lan': "someLAN"})
+
+        task_id = resp.headers['Link']
+        expected = '<https://localhost/api/1/inf/gateway/task/asdf-asdf-asdf>; rel=status'
 
         self.assertEqual(task_id, expected)
 
@@ -65,6 +86,15 @@ class TestGatewayView(unittest.TestCase):
 
         self.assertEqual(task_id, expected)
 
+    def test_delete_task_link(self):
+        """GatewayView - DELETE on /api/1/inf/gateway sets the Link header"""
+        resp = self.app.delete('/api/1/inf/gateway',
+                            headers={'X-Auth': self.token})
+
+        task_id = resp.headers['Link']
+        expected = '<https://localhost/api/1/inf/gateway/task/asdf-asdf-asdf>; rel=status'
+
+        self.assertEqual(task_id, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/vlab_gateway_api/lib/views/gateway_view.py
+++ b/vlab_gateway_api/lib/views/gateway_view.py
@@ -4,7 +4,7 @@ Defines the HTTP API for working with network gateways in vLab
 """
 import ujson
 from flask import current_app
-from flask_classy import request, route
+from flask_classy import request, route, Response
 from jsonschema import validate, ValidationError
 from vlab_inf_common.views import TaskView
 from vlab_api_common import describe, get_logger, requires, validate_input
@@ -16,7 +16,7 @@ logger = get_logger(__name__, loglevel=const.VLAB_GATEWAY_LOG_LEVEL)
 
 class GatewayView(TaskView):
     """Defines the HTTP API for working with virtual local area networks"""
-    route_base = 'api/1/inf/gateway'
+    route_base = '/api/1/inf/gateway'
     POST_SCHEMA = { "$schema": "http://json-schema.org/draft-04/schema#",
                     "type": "object",
                     "properties": {
@@ -40,28 +40,37 @@ class GatewayView(TaskView):
     def get(self, *args, **kwargs):
         """Obtain a info about the gateways a user owns"""
         username = kwargs['token']['username']
-        resp = {'user' : username}
+        resp_data = {'user' : username}
         task = current_app.celery_app.send_task('gateway.show', [username])
-        resp['content'] = {'task-id': task.id}
-        return ujson.dumps(resp), 200
+        resp_data['content'] = {'task-id': task.id}
+        resp = Response(ujson.dumps(resp_data))
+        resp.status_code = 202
+        resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
+        return resp
 
     @requires(verify=False, version=(1,2)) # XXX remove verify=False before commit
     @validate_input(schema=POST_SCHEMA)
     def post(self, *args, **kwargs):
         """Create a new gateway"""
         username = kwargs['token']['username']
-        resp = {'user' : username}
+        resp_data = {'user' : username}
         wan = kwargs['body']['wan']
         lan = kwargs['body']['lan']
         task = current_app.celery_app.send_task('gateway.create', [username, wan, lan])
-        resp['content'] = {'task-id': task.id}
-        return ujson.dumps(resp), 200
+        resp_data['content'] = {'task-id': task.id}
+        resp = Response(ujson.dumps(resp_data))
+        resp.status_code = 202
+        resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
+        return resp
 
     @requires(verify=False, version=(1,2)) # XXX remove verify=False before commit
     def delete(self, *args, **kwargs):
         """Delete a gateway"""
         username = kwargs['token']['username']
-        resp = {'user' : username}
+        resp_data = {'user' : username}
         task = current_app.celery_app.send_task('gateway.delete', [username])
-        resp['content'] = {'task-id': task.id}
-        return ujson.dumps(resp), 200
+        resp_data['content'] = {'task-id': task.id}
+        resp = Response(ujson.dumps(resp_data))
+        resp.status_code = 202
+        resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
+        return resp


### PR DESCRIPTION
Setting the Link header to the URI for checking the status simplifies client-side logic, and helps to decouple the client logic from the vLab API.

After this update, when a client performs a GET/POST/DELETE on `/api/1/inf/gateway`, the server will set the Link header like so:

```
HTTP 1.1/ 202 OK
...
Link: <https://<vlab url>/api/1/inf/gateway/task/<task id>; rel=status
```

Clients like Python's Request lib will automatically parse that header into a usable thingy like:
```
resp = requests.get('https://<vlab url>/api/1/inf/gateway
resp.links['status']
'https://<vlab url>/api/1/inf/gateway/task/<task id>'
```

Once this is merged, I'll start pushing this same type of update to all other vLab services.