### PR TITLE
tasks log transaction id, note is json object, verify is toggable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-gateway-api",
       author="Nicholas Willhite",
       author_email='willnx84@gmail.com',
-      version='2018.07.25',
+      version='2018.11.29',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_gatewway_api' : ['app.ini']},

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -10,62 +10,69 @@ from vlab_gateway_api.lib.worker import tasks
 
 class TestTasks(unittest.TestCase):
     """A set of test cases for tasks.py"""
+
+    @patch.object(tasks, 'get_task_logger')
     @patch.object(tasks, 'vmware')
-    def test_show_ok(self, fake_vmware):
+    def test_show_ok(self, fake_vmware, fake_get_task_logger):
         """``show`` returns a dictionary when everything works as expected"""
         fake_vmware.show_gateway.return_value = {'worked': True}
 
-        output = tasks.show(username='bob')
+        output = tasks.show(username='bob', txn_id='myId')
         expected = {'content' : {'worked': True}, 'error': None, 'params': {}}
 
         self.assertEqual(output, expected)
 
+    @patch.object(tasks, 'get_task_logger')
     @patch.object(tasks, 'vmware')
-    def test_show_value_error(self, fake_vmware):
+    def test_show_value_error(self, fake_vmware, fake_get_task_logger):
         """``show`` sets the error in the dictionary to the ValueError message"""
         fake_vmware.show_gateway.side_effect = [ValueError("testing")]
 
-        output = tasks.show(username='bob')
+        output = tasks.show(username='bob', txn_id='myId')
         expected = {'content' : {}, 'error': 'testing', 'params': {}}
 
         self.assertEqual(output, expected)
 
+    @patch.object(tasks, 'get_task_logger')
     @patch.object(tasks, 'vmware')
-    def test_create_ok(self, fake_vmware):
+    def test_create_ok(self, fake_vmware, fake_get_task_logger):
         """``create`` returns a dictionary when everything works as expected"""
         fake_vmware.create_gateway.return_value = {'worked': True}
 
-        output = tasks.create(username='bob', wan='SomeWan', lan='someLan')
+        output = tasks.create(username='bob', wan='SomeWan', lan='someLan', txn_id='myId')
         expected = {'content' : {'worked': True}, 'error': None, 'params': {}}
 
         self.assertEqual(output, expected)
 
+    @patch.object(tasks, 'get_task_logger')
     @patch.object(tasks, 'vmware')
-    def test_create_value_error(self, fake_vmware):
+    def test_create_value_error(self, fake_vmware, fake_get_task_logger):
         """``create`` sets the error in the dictionary to the ValueError message"""
         fake_vmware.create_gateway.side_effect = [ValueError("testing")]
 
-        output = tasks.create(username='bob', wan='SomeWan', lan='someLan')
+        output = tasks.create(username='bob', wan='SomeWan', lan='someLan', txn_id='myId')
         expected = {'content' : {}, 'error': 'testing', 'params': {}}
 
         self.assertEqual(output, expected)
 
+    @patch.object(tasks, 'get_task_logger')
     @patch.object(tasks, 'vmware')
-    def test_delete_ok(self, fake_vmware):
+    def test_delete_ok(self, fake_vmware, fake_get_task_logger):
         """``delete`` returns a dictionary when everything works as expected"""
         fake_vmware.delete_gateway.return_value = {'worked': True}
 
-        output = tasks.delete(username='bob')
+        output = tasks.delete(username='bob', txn_id='myId')
         expected = {'content' : {'worked': True}, 'error': None, 'params': {}}
 
         self.assertEqual(output, expected)
 
+    @patch.object(tasks, 'get_task_logger')
     @patch.object(tasks, 'vmware')
-    def test_delete_value_error(self, fake_vmware):
+    def test_delete_value_error(self, fake_vmware, fake_get_task_logger):
         """``delete`` sets the error in the dictionary to the ValueError message"""
         fake_vmware.delete_gateway.side_effect = [ValueError("testing")]
 
-        output = tasks.delete(username='bob')
+        output = tasks.delete(username='bob', txn_id='myId')
         expected = {'content' : {}, 'error': 'testing', 'params': {}}
 
         self.assertEqual(output, expected)

--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -144,7 +144,7 @@ class TestVMware(unittest.TestCase):
         fake_result.exitCode = 1
         fake_run_command.side_effect = [fake_result, MagicMock(), MagicMock(),  MagicMock()]
 
-        result = vmware._setup_gateway(vcenter=fake_vcenter, the_vm=fake_vm, username='jane')
+        result = vmware._setup_gateway(vcenter=fake_vcenter, the_vm=fake_vm, username='jane', gateway_version='1.0.0')
 
         self.assertTrue(result is None)
 

--- a/vlab_gateway_api/lib/constants.py
+++ b/vlab_gateway_api/lib/constants.py
@@ -23,6 +23,7 @@ DEFINED = OrderedDict([
             ('VLAB_IPAM_ADMIN_PW', environ.get('VLAB_IPAM_ADMIN_PW', "I'm a little tea pot")),
             ('VLAB_IPAM_KEY', environ.get('VLAB_IPAM_KEY', 'bGfKJfkoAPcvG3dORQuWCBXbGLtl6L9_iSfaKfaLEHY=')),
             ('VLAB_IPAM_BROKER', environ.get('VLAB_IPAM_BROKER', 'localhost:9092')),
+            ('VLAB_VERIFY_TOKEN', environ.get('VLAB_VERIFY_TOKEN', False)),
           ])
 
 Constants = namedtuple('Constants', list(DEFINED.keys()))

--- a/vlab_gateway_api/lib/views/gateway_view.py
+++ b/vlab_gateway_api/lib/views/gateway_view.py
@@ -41,14 +41,15 @@ class GatewayView(TaskView):
         """Obtain a info about the gateways a user owns"""
         username = kwargs['token']['username']
         resp_data = {'user' : username}
-        task = current_app.celery_app.send_task('gateway.show', [username])
+        txn_id = request.headers.get('X-REQUEST-ID', 'noId')
+        task = current_app.celery_app.send_task('gateway.show', [username, txn_id])
         resp_data['content'] = {'task-id': task.id}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202
         resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
         return resp
 
-    @requires(verify=False, version=2) # XXX remove verify=False before commit
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=2)
     @validate_input(schema=POST_SCHEMA)
     def post(self, *args, **kwargs):
         """Create a new gateway"""
@@ -56,19 +57,21 @@ class GatewayView(TaskView):
         resp_data = {'user' : username}
         wan = kwargs['body']['wan']
         lan = kwargs['body']['lan']
-        task = current_app.celery_app.send_task('gateway.create', [username, wan, lan])
+        txn_id = request.headers.get('X-REQUEST-ID', 'noId')
+        task = current_app.celery_app.send_task('gateway.create', [username, wan, lan, txn_id])
         resp_data['content'] = {'task-id': task.id}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202
         resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
         return resp
 
-    @requires(verify=False, version=2)# XXX remove verify=False before commit
+    @requires(verify=const.VLAB_VERIFY_TOKEN, version=2)
     def delete(self, *args, **kwargs):
         """Delete a gateway"""
         username = kwargs['token']['username']
         resp_data = {'user' : username}
-        task = current_app.celery_app.send_task('gateway.delete', [username])
+        txn_id = request.headers.get('X-REQUEST-ID', 'noId')
+        task = current_app.celery_app.send_task('gateway.delete', [username, txn_id])
         resp_data['content'] = {'task-id': task.id}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202

--- a/vlab_gateway_api/lib/worker/tasks.py
+++ b/vlab_gateway_api/lib/worker/tasks.py
@@ -3,19 +3,17 @@
 Entry point logic for available backend worker tasks
 """
 from celery import Celery
-from celery.utils.log import get_task_logger
+from vlab_api_common import get_task_logger
 
 from vlab_gateway_api.lib import const
 from vlab_gateway_api.lib.worker import vmware
 
 
 app = Celery('gateway', backend='rpc://', broker=const.VLAB_MESSAGE_BROKER)
-logger = get_task_logger(__name__)
-logger.setLevel(const.VLAB_GATEWAY_LOG_LEVEL.upper())
 
 
-@app.task(name='gateway.show')
-def show(username):
+@app.task(name='gateway.show', bind=True)
+def show(self, username, txn_id):
     """Obtain basic information about a user's default gateway
 
     :Returns: Dictionary
@@ -23,6 +21,7 @@ def show(username):
     :param username: The name of the user who wants info about their default gateway
     :type username: String
     """
+    logger = get_task_logger(txn_id=txn_id, task_id=self.request.id, loglevel=const.VLAB_GATEWAY_LOG_LEVEL.upper())
     resp = {'content' : {}, 'error': None, 'params': {}}
     try:
         logger.info('Task starting')
@@ -36,8 +35,8 @@ def show(username):
     return resp
 
 
-@app.task(name='gateway.create')
-def create(username, wan, lan):
+@app.task(name='gateway.create', bind=True)
+def create(self, username, wan, lan, txn_id):
     """Deploy a new default gateway
 
     :Returns: Dictionary
@@ -48,6 +47,7 @@ def create(username, wan, lan):
     :param network: The name of the network that the jumpbox connects to.
     :type network: String
     """
+    logger = get_task_logger(txn_id=txn_id, task_id=self.request.id, loglevel=const.VLAB_GATEWAY_LOG_LEVEL.upper())
     resp = {'content' : {}, 'error': None, 'params': {}}
     try:
         logger.info('Task starting')
@@ -59,8 +59,8 @@ def create(username, wan, lan):
     return resp
 
 
-@app.task(name='gateway.delete')
-def delete(username):
+@app.task(name='gateway.delete', bind=True)
+def delete(self, username, txn_id):
     """Destroy the default gateway
 
     :Returns: Dictionary
@@ -68,6 +68,7 @@ def delete(username):
     :param username: The name of the user who wants to create a new default gateway
     :type username: String
     """
+    logger = get_task_logger(txn_id=txn_id, task_id=self.request.id, loglevel=const.VLAB_GATEWAY_LOG_LEVEL.upper())
     resp = {'content' : {}, 'error': None, 'params': {}}
     try:
         logger.info('Task starting')


### PR DESCRIPTION
The point of this PR is to prep the service for the v2 Beta.
Fixes include:

1. API - verify param for token validation can now be toggled on/off via config
2. Only v2 token are accepted
3. Tasks log the client-supplied transaction id
4. Deployed gateways store meta data as a JSON object instead of a string