### PR TITLE
Bug doh

### DIFF
--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -154,7 +154,10 @@ class TestVMware(unittest.TestCase):
         fake_vm = MagicMock()
         fake_result = MagicMock()
         fake_result.exitCode = 1
-        fake_run_command.side_effect = [fake_result, MagicMock(), MagicMock(),  MagicMock()]
+        # one Mock for every setup cmd that gets ran
+        fake_run_command.side_effect = [fake_result, MagicMock(), MagicMock(),
+                                        MagicMock(),  MagicMock(),  MagicMock(),
+                                        MagicMock()]
 
         result = vmware._setup_gateway(vcenter=fake_vcenter,
                                        the_vm=fake_vm,

--- a/vlab_gateway_api/lib/constants.py
+++ b/vlab_gateway_api/lib/constants.py
@@ -7,7 +7,7 @@ from collections import namedtuple, OrderedDict
 
 
 DEFINED = OrderedDict([
-            ('VLAB_URL', 'https://localhost'),
+            ('VLAB_URL', environ.get('VLAB_URL', 'https://localhost')),
             ('INF_VCENTER_SERVER', environ.get('INF_VCENTER_SERVER', 'localhost')),
             ('INF_VCENTER_PORT', int(environ.get('INFO_VCENTER_PORT', 443))),
             ('INF_VCENTER_USER', environ.get('INF_VCENTER_USER', 'someAdmin')),

--- a/vlab_gateway_api/lib/worker/vmware.py
+++ b/vlab_gateway_api/lib/worker/vmware.py
@@ -197,9 +197,45 @@ def _setup_gateway(vcenter, the_vm, username, gateway_version, logger):
     if result4.exitCode:
         logger.error('Failed to restart vlab-log-sender')
 
+    cmd5 = '/usr/bin/sudo'
+    args5 = "/bin/sed -i -e 's/VLAB_URL=https:\/\/localhost/VLAB_LOG_TARGET={}/g' /etc/environment".format(const.VLAB_URL.replace('/', '\/'))
+    result5 = virtual_machine.run_command(vcenter,
+                                          the_vm,
+                                          cmd5,
+                                          user=const.VLAB_IPAM_ADMIN,
+                                          password=const.VLAB_IPAM_ADMIN_PW,
+                                          arguments=args5)
+    if result5.exitCode:
+        logger.error('Failed to set VLAB_URL environment variable')
+
+
+    cmd6 = '/usr/bin/sudo'
+    args6 = "/bin/sed -i -e 's/PRODUCTION=false/PRODUCTION=beta/g' /etc/environment"
+    result6 = virtual_machine.run_command(vcenter,
+                                          the_vm,
+                                          cmd6,
+                                          user=const.VLAB_IPAM_ADMIN,
+                                          password=const.VLAB_IPAM_ADMIN_PW,
+                                          arguments=args6)
+    if result6.exitCode:
+        logger.error('Failed to set PRODUCTION environment variable')
+
+    cmd7 = '/usr/bin/sudo'
+    args7 = '/sbin/reboot'
+    result7 = virtual_machine.run_command(vcenter,
+                                          the_vm,
+                                          cmd6,
+                                          user=const.VLAB_IPAM_ADMIN,
+                                          password=const.VLAB_IPAM_ADMIN_PW,
+                                          arguments=args7,
+                                          one_shot=True)
+    if result7.exitCode:
+        logger.error('Failed to reboot IPAM server')
+
     meta_data = {'component': 'defaultGateway',
                  'created': time.time(),
                  'version': gateway_version,
                  'configured': True,
                  'generation': 1}
     virtual_machine.set_meta(the_vm, meta_data)
+    time.sleep(60) # Give the box time to power cycles


### PR DESCRIPTION
The `status` URL in the Link header was returning `localhost` because the `const` object never attempted to read the `VLAB_URL` environment variable.

Also, the IPAM service needed a few more configs updated, so I added those.