### PR TITLE
fixed sed command that sets VLAB_URL env var

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-gateway-api",
       author="Nicholas Willhite",
       author_email='willnx84@gmail.com',
-      version='2018.12.03',
+      version='2018.12.20',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_gatewway_api' : ['app.ini']},

--- a/vlab_gateway_api/lib/worker/vmware.py
+++ b/vlab_gateway_api/lib/worker/vmware.py
@@ -198,7 +198,7 @@ def _setup_gateway(vcenter, the_vm, username, gateway_version, logger):
         logger.error('Failed to restart vlab-log-sender')
 
     cmd5 = '/usr/bin/sudo'
-    args5 = "/bin/sed -i -e 's/VLAB_URL=https:\/\/localhost/VLAB_LOG_TARGET={}/g' /etc/environment".format(const.VLAB_URL.replace('/', '\/'))
+    args5 = "/bin/sed -i -e 's/VLAB_URL=https:\/\/localhost/VLAB_URL={}/g' /etc/environment".format(const.VLAB_URL.replace('/', '\/'))
     result5 = virtual_machine.run_command(vcenter,
                                           the_vm,
                                           cmd5,


### PR DESCRIPTION
This was a fun bug...
So, the service needs to contact the auth server to get the correct key for validating user tokens.
Kind of hard to do that when the env var that defines _where_ the server is located points to `localhost` because of a bad `sed` command 😅 