### PR TITLE
updated to support vlab_inf_common version 2019.6.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-gateway-api",
       author="Nicholas Willhite",
       author_email='willnx84@gmail.com',
-      version='2019.03.21',
+      version='2019.06.18',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_gatewway_api' : ['app.ini']},

--- a/tests/test_gateway_view.py
+++ b/tests/test_gateway_view.py
@@ -97,5 +97,16 @@ class TestGatewayView(unittest.TestCase):
 
         self.assertEqual(task_id, expected)
 
+    def test_network(self):
+        """GatewayView - PUT on /api/2/inf/gateway/network returns a 404"""
+        resp = self.app.put('/api/2/inf/gateway/network',
+                            headers={'X-Auth': self.token})
+
+        status = resp.status_code
+        expected = 404
+
+        self.assertEqual(status, expected)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/vlab_gateway_api/lib/views/gateway_view.py
+++ b/vlab_gateway_api/lib/views/gateway_view.py
@@ -77,3 +77,7 @@ class GatewayView(TaskView):
         resp.status_code = 202
         resp.headers.add('Link', '<{0}{1}/task/{2}>; rel=status'.format(const.VLAB_URL, self.route_base, task.id))
         return resp
+
+    def modify_network(self):
+        """Avoid exposing an useless API end point"""
+        pass


### PR DESCRIPTION
This update is to address changes made in willnx/vlab_inf_common#31

I opted to not implement the ability for users to change the network their NAT firewall is using.
I can't think of a good reason to allow such a thing, and can easily see all the bugs/questions that will arise of such a feature.